### PR TITLE
Fix show_spectrum

### DIFF
--- a/implementations/python/bin/show_spectrum.py
+++ b/implementations/python/bin/show_spectrum.py
@@ -18,13 +18,16 @@ from mzlib import SpectrumLibrary
 from mzlib import Spectrum
 from mzlib import UniversalSpectrumIdentifier
 
+from mzlib.backends import TextSpectralLibrary, MSPSpectralLibrary
+from mzlib.index import SQLIndex
+
 
 def main():
 
     argparser = argparse.ArgumentParser(description='Reads one spectrum from a file and prints to stdout')
 
     argparser.add_argument('--library_file', action='store', help="Name of the library file to access")
-    argparser.add_argument('--index_number', action='store', help="Index number of the spectrum to display")
+    argparser.add_argument('--index_number', action='store', help="Index number of the spectrum to display", type=int)
     argparser.add_argument('--usi', action='store', help="Universal Spectrum Identifier of the spectrum to display")
     argparser.add_argument('--output_format', action='store', default='text', help="Format use when writing the spectrum (one of 'text', 'json', 'msp')")
 
@@ -71,12 +74,12 @@ def main():
 
     os.remove(library_file + '.splindex')
 
-    spectrum_library = SpectrumLibrary(filename=library_file)
-    spectrum_library.read(create_index=True)
+    if library_file.lower().endswith(".msp"):
+        spectrum_library = MSPSpectralLibrary(library_file, SQLIndex)
+    elif library_file.lower().endswith(".mzlb.txt"):
+        spectrum_library = TextSpectralLibrary(library_file, SQLIndex)
 
-    spectrum_buffer = spectrum_library.get_spectrum(spectrum_index_number=index_number)
-    spectrum = Spectrum()
-    spectrum.parse(spectrum_buffer, spectrum_index=index_number)
+    spectrum = spectrum_library.get_spectrum(int(index_number))
     buffer = spectrum.write(format=params.output_format)
     print(buffer)
 

--- a/implementations/python/mzlib/backends/text.py
+++ b/implementations/python/mzlib/backends/text.py
@@ -216,19 +216,19 @@ class TextSpectralLibrary(_PlainTextSpectralLibraryBackendBase):
         spectrum = self._parse(buffer, spectrum_number)
         return spectrum
 
+    @staticmethod
+    def format_spectrum(spectrum):
+        buffer = io.StringIO()
+        for attribute in spectrum.attributes:
+            if len(attribute) == 2:
+                buffer.write(f"{attribute[0]}={attribute[1]}\n")
+            elif len(attribute) == 3:
+                buffer.write(f"[{attribute[2]}]{attribute[0]}={attribute[1]}\n")
+            else:
+                raise ValueError(f"Attribute has wrong number of elements: {attribute}")
+        for peak in spectrum.peak_list:
+            buffer.write("\t".join(map(str, peak))+"\n")
+        return buffer.getvalue()
 
-@staticmethod
-def format_spectrum(spectrum):
-    buffer = io.StringIO()
-    for attribute in spectrum.attributes:
-        if len(attribute) == 2:
-            buffer.write(f"{attribute[0]}={attribute[1]}\n")
-        elif len(attribute) == 3:
-            buffer.write(f"[{attribute[2]}]{attribute[0]}={attribute[1]}\n")
-        else:
-            raise ValueError(f"Attribute has wrong number of elements: {attribute}")
-    for peak in spectrum.peak_list:
-        buffer.write("\t".join(map(str, peak))+"\n")
-    return buffer.getvalue()
 
-
+format_spectrum = TextSpectralLibrary.format_spectrum

--- a/implementations/python/mzlib/index/base.py
+++ b/implementations/python/mzlib/index/base.py
@@ -1,3 +1,5 @@
+import warnings
+
 class IndexBase(object):
 
     @classmethod

--- a/implementations/python/mzlib/index/sql.py
+++ b/implementations/python/mzlib/index/sql.py
@@ -113,7 +113,8 @@ class SQLIndex(IndexBase):
                 SpectrumLibraryIndexRecord.number < end).all()
             return records
         else:
-            records = self.session.query(SpectrumLibraryIndexRecord.name == i).all()
+            records = self.session.query(SpectrumLibraryIndexRecord).filter(
+                SpectrumLibraryIndexRecord.name == i).all()
             if not records:
                 raise KeyError(i)
             elif len(records) == 1:

--- a/implementations/python/mzlib/test/test_spectrum.py
+++ b/implementations/python/mzlib/test/test_spectrum.py
@@ -1,0 +1,32 @@
+import os
+import unittest
+
+import tempfile
+
+from mzlib.backends import MSPSpectralLibrary, TextSpectralLibrary
+from mzlib.test.common import datafile
+
+
+class TestSpectrum(unittest.TestCase):
+
+    def get_library(self):
+        test_file = datafile("chinese_hamster_hcd_selected_head.mzlb.txt")
+        return TextSpectralLibrary(test_file)
+
+    def get_spectrum(self, index):
+        library = self.get_library()
+        return library.get_spectrum(index)
+
+    def test_write(self):
+        spectrum = self.get_spectrum(0)
+        buffer = spectrum.write('text')
+        lines = buffer.splitlines()
+        n_lines = len(lines)
+        assert n_lines == 128
+        assert buffer.startswith("MS:1003061|spectrum name")
+
+    def test_equality(self):
+        spectrum = self.get_spectrum(0)
+        spectrum2 = self.get_spectrum(0)
+        assert spectrum == spectrum2
+


### PR DESCRIPTION
This fixes `bin/show_spectrum.py` and a whitespace associated bug I introduced in a dependency of `Spectrum.write`. It also fixes an error in SQLIndex detected because I used it incorrectly.

Apologies for the inconvenience.