### PR TITLE
Implement 5/15/20 call

### DIFF
--- a/implementations/python/.gitignore
+++ b/implementations/python/.gitignore
@@ -1,7 +1,7 @@
 *.pyc
 __pycache__
 *egg-info*
-Untitled*.ipynb
+*.ipynb
 examples/*splindex
 .coverage
 htmlcov/

--- a/implementations/python/mzlib/attributes.py
+++ b/implementations/python/mzlib/attributes.py
@@ -123,6 +123,35 @@ class AttributeManager(object):
             idx = indices[i]
             return self.attributes[idx]
 
+    def replace_attribute(self, key, value, group_identifier=None):
+        indices_and_groups = self.attribute_dict[key]
+        if group_identifier is None:
+            indices = indices_and_groups['indexes']
+            if len(indices) > 1:
+                raise ValueError("Cannot replace the value of an attribute used multiple times")
+            else:
+                self.attributes[indices[0]][1] = value
+        else:
+            raise NotImplementedError()
+
+    def get_by_name(self, name):
+        '''Search for an attribute by human-readable name.
+
+        Parameters
+        ----------
+        name: str
+            The name to search for.
+
+        Returns
+        -------
+        object:
+            The attribute value if found or :const:`None`.
+        '''
+        for attr in self:
+            if attr[0].split("|")[-1] == name:
+                return attr[1]
+        return None
+
     def clear(self):
         """Remove all content from the store.
 
@@ -186,6 +215,12 @@ class AttributeManager(object):
 
     def __getitem__(self, key):
         return self.get_attribute(key)
+
+    def __setitem__(self, key, value):
+        if self.has_attribute(key):
+            self.replace_attribute(key, value)
+        else:
+            self.add_attribute(key, value)
 
     def keys(self):
         return self.attribute_dict.keys()

--- a/implementations/python/mzlib/backends/base.py
+++ b/implementations/python/mzlib/backends/base.py
@@ -217,8 +217,12 @@ class SpectralLibraryBackendBase(object, metaclass=SubclassRegisteringMetaclass)
         raise NotImplementedError()
 
     def __iter__(self):
-        for record in self.index:
-            yield self.get_spectrum(record.number)
+        if self.index:
+            for record in self.index:
+                yield self.get_spectrum(record.number)
+        else:
+            raise NotImplementedError()
+            return self.read()
 
     def __len__(self):
         return len(self.index)
@@ -300,7 +304,13 @@ class _PlainTextSpectralLibraryBackendBase(SpectralLibraryBackendBase):
     def read(self):
         with open(self.filename, 'rt') as stream:
             i = 0
+            match, offset = self._parse_header_from_stream(stream)
+            if not match:
+                raise ValueError("Could not locate valid header")
+            else:
+                stream.seek(offset)
             while True:
+                # Will clip the first line of the next spectrum. Needs work
                 buffer = self._buffer_from_stream(stream)
                 if not buffer:
                     break

--- a/implementations/python/mzlib/backends/utils.py
+++ b/implementations/python/mzlib/backends/utils.py
@@ -1,3 +1,29 @@
+from collections import deque
+
+class LineBuffer(object):
+    def __init__(self, stream, lines=None):
+        if lines is None:
+            lines = []
+        self.lines = deque(lines)
+        self.stream = stream
+
+    def readline(self):
+        if self.lines:
+            self.lines.popleft()
+        else:
+            return self.stream.readline()
+
+    def push_line(self, line):
+        self.lines.appendleft(line)
+
+    def __iter__(self):
+        while self.lines:
+            yield self.lines.popleft
+        for line in self.stream:
+            yield line
+
+    def __getattr__(self, attr):
+        return getattr(self.stream, attr)
 
 
 def try_cast(value):

--- a/implementations/python/mzlib/spectrum.py
+++ b/implementations/python/mzlib/spectrum.py
@@ -8,6 +8,8 @@ from mzlib.attributes import AttributeManager
 
 #A class that holds data for each spectrum that is read from the SpectralLibrary class
 
+SPECTRUM_NAME = "MS:1003061|spectrum name"
+
 
 class Spectrum(AttributeManager):
 
@@ -29,6 +31,22 @@ class Spectrum(AttributeManager):
         self.peak_list = peak_list
         self.analytes = analytes
 
+    @property
+    def name(self):
+        return self.get_attribute(SPECTRUM_NAME)
+
+    @name.setter
+    def name(self, value):
+        if self.has_attribute(SPECTRUM_NAME):
+            self.replace_attribute(SPECTRUM_NAME, value)
+        elif AttributeManager.__len__(self) > 0:
+            attribs = [SPECTRUM_NAME, value] + list(
+                AttributeManager.__iter__(self))
+            AttributeManager.clear(self)
+            AttributeManager._from_iterable(attribs)
+        else:
+            self.add_attribute(SPECTRUM_NAME, value)
+
     def __eq__(self, other):
         result = super(Spectrum, self).__eq__(other)
         if result:
@@ -37,7 +55,7 @@ class Spectrum(AttributeManager):
             result = self.analytes == other.analytes
         return result
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         template = f"{self.__class__.__name__}("
         lines = list(map(str, self.attributes))
         if not lines:
@@ -52,10 +70,10 @@ class Spectrum(AttributeManager):
                 ',\n'.join(lines), ' ' * 2)
         return template
 
-    def __str__(self):
+    def __str__(self):  # pragma: no cover
         return self.write("text")
 
-    def write(self, format="text"):
+    def write(self, format="text"):  # pragma: no cover
         """
         write - Write out the spectrum in any of the supported formats
         """

--- a/implementations/python/mzlib/spectrum_library.py
+++ b/implementations/python/mzlib/spectrum_library.py
@@ -119,7 +119,7 @@ class SpectrumLibrary:
     @property
     def attributes(self):
         if self._backend_initialized():
-            return self.backend
+            return self.backend.attributes
         return None
 
     def read_header(self):
@@ -130,7 +130,12 @@ class SpectrumLibrary:
         bool:
             Whether the operation was successful
         """
+        self._requires_backend()
         return self.backend.read_header()
+
+    def read(self):
+        self._requires_backend()
+        return self.backend.read()
 
     def write(self, destination, format=None):
         """Write the library to disk

--- a/implementations/python/tests/test_annotation.py
+++ b/implementations/python/tests/test_annotation.py
@@ -45,3 +45,15 @@ class TestAnnotationParser(unittest.TestCase):
         assert parsed.isotope == 2
         assert parsed.charge == 2
         assert parsed.mass_error == MassError(0.5, 'ppm')
+
+        base = "2@" + base
+
+        parsed = parse_annotation(base)[0]
+        assert parsed.series == 'b'
+        assert parsed.position == 14
+        assert parsed.neutral_loss == "-H2O-NH3+[Foo]"
+        assert parsed.isotope == 2
+        assert parsed.charge == 2
+        assert parsed.mass_error == MassError(0.5, 'ppm')
+        assert parsed.analyte_reference == '2'
+        assert parsed == base

--- a/implementations/python/tests/test_library_backend.py
+++ b/implementations/python/tests/test_library_backend.py
@@ -20,6 +20,11 @@ class LibraryBehaviorBase(object):
         assert spec.get_attribute(
             "MS:1003061|spectrum name") == "AAAAGSTSVKPIFSR/2_0_44eV"
 
+    # TODO: Fix clipping in _buffer_from_stream first
+    # def test_iteration(self):
+    #     lib = self._open_library()
+    #     assert list(lib) == list(lib.read())
+
 
 class TestMSPLibrary(unittest.TestCase, LibraryBehaviorBase):
     test_file = datafile("chinese_hamster_hcd_selected_head.msp")


### PR DESCRIPTION
This PR contains
1. Fixes for the immonium ion modification notation (`IC[Carbamidomethyl]` instead of `[IC+[Carbamidomethyl]`)
2. Updates to the new reporter ion notation `r[TMT128]` instead of `r128.XXX`
3. Improves the parsing of modified immonium ions in MSP.
4. Moves the analyte reference to the front of the peak annotation
5. Implements basic header for text format serialization.

Incremental progress on sequential parsing.